### PR TITLE
fix syntax error

### DIFF
--- a/swift-2048/AppDelegate.swift
+++ b/swift-2048/AppDelegate.swift
@@ -14,11 +14,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
   var window: UIWindow?
 
 
-  func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: NSDictionary?) -> Bool {
-    // Override point for customization after application launch.
-    return true
-  }
-
+    func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject : AnyObject]?) -> Bool {
+        return true
+    }
   func applicationWillResignActive(application: UIApplication) {
     // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
     // Use this method to pause ongoing tasks, disable timers, and throttle down OpenGL ES frame rates. Games should use this method to pause the game.

--- a/swift-2048/NumberTileGame.swift
+++ b/swift-2048/NumberTileGame.swift
@@ -102,7 +102,7 @@ class NumberTileGameViewController : UIViewController, GameModelProtocol {
       assert(views.count > 0)
       assert(order >= 0 && order < views.count)
       let viewHeight = views[order].bounds.size.height
-      let totalHeight = CGFloat(views.count - 1)*viewPadding + views.map({ $0.bounds.size.height }).reduce(verticalViewOffset, { $0 + $1 })
+      let totalHeight = CGFloat(views.count - 1)*viewPadding + views.map({ $0.bounds.size.height }).reduce(verticalViewOffset, combine: { $0 + $1 })
       let viewsTop = 0.5*(vcHeight - totalHeight) >= 0 ? 0.5*(vcHeight - totalHeight) : 0
 
       // Not sure how to slice an array yet


### PR DESCRIPTION
Fix syntax error on swift 1.2,now it can run on iOS 8.4 and compiled by
Xcode 6.4