### PR TITLE
new game after win or lose

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ If you want to check out a more advanced Swift project, please take a look at **
 Instructions
 ------------
 
-You will need Xcode 7 to run the project. Run it in the simulator or on an actual device.
+You will need Xcode 7 to run the project. Run it in the simulator or on an actual device with iOS 8.0+.
 
 Tap the button to play the game. Swipe to move the tiles.
 

--- a/swift-2048/NumberTileGame.swift
+++ b/swift-2048/NumberTileGame.swift
@@ -164,11 +164,10 @@ class NumberTileGameViewController : UIViewController, GameModelProtocol {
     let (userWon, _) = m.userHasWon()
     if userWon {
       // TODO: alert delegate we won
-      let alertView = UIAlertView()
-      alertView.title = "Victory"
-      alertView.message = "You won!"
-      alertView.addButton(withTitle: "Cancel")
-      alertView.show()
+      let alertView = UIAlertController(title: "Victory", message: "You won!", preferredStyle: .alert)
+      alertView.addAction(UIAlertAction(title: "New Game", style: .default, handler: {action in self.reset()}))
+      alertView.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: nil))
+      self.present(alertView, animated: true)
       // TODO: At this point we should stall the game until the user taps 'New Game' (which hasn't been implemented yet)
       return
     }
@@ -181,11 +180,10 @@ class NumberTileGameViewController : UIViewController, GameModelProtocol {
     if m.userHasLost() {
       // TODO: alert delegate we lost
       NSLog("You lost...")
-      let alertView = UIAlertView()
-      alertView.title = "Defeat"
-      alertView.message = "You lost..."
-      alertView.addButton(withTitle: "Cancel")
-      alertView.show()
+      let alertView = UIAlertController(title: "Defeat", message: "You lost...", preferredStyle: .alert)
+      alertView.addAction(UIAlertAction(title: "New Game", style: .default, handler: {action in self.reset()}))
+      alertView.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: nil))
+      self.present(alertView, animated: true)
     }
   }
 

--- a/swift-2048/NumberTileGame.swift
+++ b/swift-2048/NumberTileGame.swift
@@ -163,12 +163,11 @@ class NumberTileGameViewController : UIViewController, GameModelProtocol {
     let m = model!
     let (userWon, _) = m.userHasWon()
     if userWon {
-      // TODO: alert delegate we won
+      // alert delegate we won
       let alertView = UIAlertController(title: "Victory", message: "You won!", preferredStyle: .alert)
       alertView.addAction(UIAlertAction(title: "New Game", style: .default, handler: {action in self.reset()}))
       alertView.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: nil))
       self.present(alertView, animated: true)
-      // TODO: At this point we should stall the game until the user taps 'New Game' (which hasn't been implemented yet)
       return
     }
 
@@ -178,7 +177,7 @@ class NumberTileGameViewController : UIViewController, GameModelProtocol {
 
     // At this point, the user may lose
     if m.userHasLost() {
-      // TODO: alert delegate we lost
+      // alert delegate we lost
       NSLog("You lost...")
       let alertView = UIAlertController(title: "Defeat", message: "You lost...", preferredStyle: .alert)
       alertView.addAction(UIAlertAction(title: "New Game", style: .default, handler: {action in self.reset()}))


### PR DESCRIPTION
No more swipe up after each game ends.  Choose "New Game" and continue.

Verified on Xcode 10.1, iOS 8.4